### PR TITLE
Support carriage returns

### DIFF
--- a/src/documentSymbolProvider.ts
+++ b/src/documentSymbolProvider.ts
@@ -40,7 +40,7 @@ export class PerlDocumentSymbolProvider implements vscode.DocumentSymbolProvider
 
     // TODO: replace with better regexp
     private get pattern() {
-        return /(^package|\bsub|\bsubtest)\b +([^ ;\n'"{]+|(['"].+['"])+)/gm;
+        return /(^package|\bsub|\bsubtest)\b +([^ ;\r\n'"{]+|(['"].+['"])+)/gm;
     }
 
     private matchAll(


### PR DESCRIPTION
Fix for CRLF files like
```pl
sub foo
{
    return 1;
}
``` 